### PR TITLE
Added PriorityClassName field

### DIFF
--- a/charts/docreader/templates/deployment.yaml
+++ b/charts/docreader/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -42,6 +42,8 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1001
 
+# priorityClassName: ""
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
**What?**
Adds Pods prioirity to helm chart

**Why?**

An essential part of k8 is having the ability to create a pod priority. 

This PR adds this functionality for the docreader helm chart. 