### PR TITLE
Docreader/release 0.5.0

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,8 +3,8 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 0.4.0
-appVersion: 6.7.201541.621
+version: 0.5.0
+appVersion: 6.8.214700.665
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/docreader/templates/config.tpl
+++ b/charts/docreader/templates/config.tpl
@@ -18,7 +18,10 @@ REGULA_RETURN_SYSTEMINFO="{{ .Values.general.returnSystemInfo }}"
 {{- end }}
 
 # HTTPS
+{{- if .Values.https.enabled }}
 DOCREADER_HTTPS="{{ .Values.https.enabled }}"
+DOCREADER_TLS_VERSION="{{ default "1.2" .Values.https.tlsVersion }}"
+{{- end }}
 
 # CORS
 {{- if .Values.cors.origins }}

--- a/charts/docreader/templates/deployment.yaml
+++ b/charts/docreader/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /api/ping
+              path: /api/readiness
               port: docreader
               {{- if .Values.https.enabled }}
               scheme: HTTPS

--- a/charts/docreader/templates/hpa.yaml
+++ b/charts/docreader/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- if (semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion)}}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "docreader.fullname" . }}
@@ -17,12 +21,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if (semverCompare "<1.23-0" .Capabilities.KubeVersion.GitVersion)}}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -119,6 +119,9 @@ https:
 
   # certificatesSecretName: certificates
   certificatesSecretName: ~
+  # Specifies the version of the TLS (Transport Layer Security) protocol to use for secure connections within the application.
+  # String type, accepts the following available versions of TLS: 1.0, 1.1, 1.2, 1.3
+  tlsVersion: ~
 
 
 rfidpkd:


### PR DESCRIPTION
- [Support DOCREADER_TLS_VERSION environment variable]
- [HPA. Add support for KubeVersion >=1.23-0]
- [Set new readiness probe endpoint]