### PR TITLE
`docreader`. 1.0.1 release

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 1.0.0
+version: 1.0.1
 appVersion: 7.1.259217.1262
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -213,7 +213,6 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 
 | Parameter                                                         | Description                                                                                   | Default                               |
 |-------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|---------------------------------------|
-| `config.service.processing.ecdhSchema`                            | ECDH schema to use                                                                            | `default`                             |
 | `config.service.processing.results.enabled`                       | Whether to enable processing                                                                  | `false`                               |
 | `config.service.processing.results.location.bucket`               | The processing results bucket name in case of `s3`/`gcs` storage type                         | `""`                                  |
 | `config.service.processing.results.location.container`            | The processing results storage container name in case of `az` storage type                    | `""`                                  |

--- a/charts/docreader/templates/config.tpl
+++ b/charts/docreader/templates/config.tpl
@@ -95,7 +95,6 @@ service:
   processing:
     enabled: {{ .Values.config.service.processing.enabled }}
     {{- if .Values.config.service.processing.enabled }}
-    ecdhSchema: {{ quote .Values.config.service.processing.ecdhSchema }}
     results:
       saveResult: {{ .Values.config.service.processing.results.saveResult }}
       location:

--- a/charts/docreader/templates/session-api-transactions-pvc.yaml
+++ b/charts/docreader/templates/session-api-transactions-pvc.yaml
@@ -10,11 +10,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.config.service.sessionApi.transactions.persistence.size | quote }}
-  {{- if .Values.config.service.sessionApi.transactions.storageClassName }}
-  {{- if (eq "-" .Values.config.service.sessionApi.transactions.storageClassName) }}
+  {{- if .Values.config.service.sessionApi.transactions.persistence.storageClassName }}
+  {{- if (eq "-" .Values.config.service.sessionApi.transactions.persistence.storageClassName) }}
   storageClassName: ""
   {{- else }}
-  storageClassName: "{{ .Values.config.service.sessionApi.transactions.storageClassName }}"
+  storageClassName: "{{ .Values.config.service.sessionApi.transactions.persistence.storageClassName }}"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -178,7 +178,6 @@ config:
 
     processing:
       enabled: true
-      ecdhSchema: "default"
       results:
         saveResult: false
         location:


### PR DESCRIPTION
- [Temporary remove processing.ecdhSchema to fallback into default value `prime256v1`](https://github.com/regulaforensics/helm-charts/commit/ce6517f0b8956c660c676cdc1f775c48b0b5ebb5)
- [Fix session-api-transactions-pvc template](https://github.com/regulaforensics/helm-charts/commit/fab3d29b71e89e8370778b8d3dfc1066cff0e50e)