### PR TITLE
Migrate liveness/readiness/startup probes to healthz/readyz

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 1.2.3
+version: 1.2.4
 appVersion: 7.4.293365.1641
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -177,7 +177,7 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 | Parameter                                                 | Description                                                                       | Default                                                       |
 |-----------------------------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
 | `licenseSecretName`                                       | The name of an existing secret containing the regula.license file                 | `""`                                                          |
-| `config.sdk.systemInfo.returnSystemInfo`                  | Whether to hide system info (/api/ping response)                                  | `true`                                                        |
+| `config.sdk.systemInfo.returnSystemInfo`                  | Whether to hide system info (/api/healthz response)                               | `true`                                                        |
 | `config.sdk.rfid.enabled`                                 | Whether to enable RFID PKD PA mode                                                | `false`                                                       |
 | `config.sdk.rfid.pkdPaPath`                               | RFID PKD PA certificates path                                                     | `"/app/pkdPa"`                                                |
 | `config.sdk.rfid.pkdPaExistingClaim`                      | Name of the existing Persistent Volume Claim containing RFID PKD PA certificates  | `""`                                                          |

--- a/charts/docreader/templates/deployment.yaml
+++ b/charts/docreader/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /api/ping
+              path: /api/healthz
               port: docreader
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS
@@ -69,7 +69,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /api/readiness
+              path: /api/readyz
               port: docreader
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS
@@ -85,7 +85,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: /api/readiness
+              path: /api/readyz
               port: docreader
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -79,7 +79,7 @@ licenseSecretName: ~
 config:
   sdk:
     systemInfo:
-      # Returns system information in the /api/ping response and in the /api/process response.
+      # Returns system information in the /api/healthz response and in the /api/process response.
       returnSystemInfo: true
 
     rfid:

--- a/charts/faceapi/Chart.yaml
+++ b/charts/faceapi/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: faceapi
 home: https://faceapi.regulaforensics.com/
-version: 1.2.3
+version: 1.2.4
 appVersion: 6.2.435.1130
 description: Face Recognition Service. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/faceapi/templates/deployment.yaml
+++ b/charts/faceapi/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /api/ping
+              path: /api/healthz
               port: faceapi
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS
@@ -69,7 +69,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /api/readiness
+              path: /api/readyz
               port: faceapi
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS
@@ -85,7 +85,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: /api/readiness
+              path: /api/readyz
               port: faceapi
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS


### PR DESCRIPTION
## Summary

Migrate probes:
- liveness /api/ping ➝ /api/healthz
- readiness /api/readiness ➝ /api/readyz
- startup /api/readiness ➝ /api/readyz
