### PR TITLE
[Docreader] Change probes, add Housekeeper, add migration Job

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 1.3.3
+version: 2.0.0
 appVersion: 7.5.306867.1848
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
 version: 2.0.0
-appVersion: 7.5.306867.1848
+appVersion: 7.6.309246.1921
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -178,7 +178,7 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 | Parameter                                                 | Description                                                                       | Default                                                       |
 |-----------------------------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------------------|
 | `licenseSecretName`                                       | The name of an existing secret containing the regula.license file                 | `""`                                                          |
-| `config.sdk.systemInfo.returnSystemInfo`                  | Whether to hide system info (/api/ping response)                                  | `true`                                                        |
+| `config.sdk.systemInfo.returnSystemInfo`                  | Whether to hide system info (/api/healthz response)                               | `true`                                                        |
 | `config.sdk.rfid.enabled`                                 | Whether to enable RFID PKD PA mode                                                | `false`                                                       |
 | `config.sdk.rfid.pkdPaPath`                               | RFID PKD PA certificates path                                                     | `"/app/pkdPa"`                                                |
 | `config.sdk.rfid.pkdPaExistingClaim`                      | Name of the existing Persistent Volume Claim containing RFID PKD PA certificates  | `""`                                                          |

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -258,6 +258,15 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 | `config.service.sessionApi.transactions.persistence.storageClassName` | The Session API logs data Persistent Volume storage Class                                          | `""`                                         |
 | `config.service.sessionApi.transactions.persistence.existingClaim`    | Name of the existing Persistent Volume Claim                                                       | `""`                                         |
 
+## HouseKeeper parameters
+
+| Parameter                                       | Description                                                        | Default    |
+|-------------------------------------------------|--------------------------------------------------------------------|------------|
+| `config.service.houseKeeper.enabled`            | Whether to enable HouseKeeper                                      | `false`    |
+| `config.service.houseKeeper.beatCadence`        | HouseKeeper beat cadence in seconds                                | `10`       |
+| `config.service.houseKeeper.keepFor`            | Time for keeping houseKeeper statistics in the database in seconds | `14400`    |
+| `config.service.houseKeeper.sessionApi.enabled` | Whether to enable clearing data for sessionApi                     | `false`    |
+| `config.service.houseKeeper.sessionApi.keepFor` | Time for keeping data for sessionApi in seconds                    | `31536000` |
 
 ## SDK Error Logs parameters
 | Parameter                                                 | Description                                                                             | Default                         |

--- a/charts/docreader/templates/NOTES.txt
+++ b/charts/docreader/templates/NOTES.txt
@@ -6,8 +6,12 @@
 ***********************************************************************
 
 Chart version: {{ .Chart.Version }}
-Docreader version compatibility: >= 7.1
+Docreader version compatibility: >= 7.6
 Kubernetes version compatibility: >= 1.23.0
+
+{{- if eq .Values.image.tag "latest" }}
+NOTE: Do not use "latest" mutable tag in production. Mutable tags can introduce multiple functional and security issues.
+{{- end }}
 
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}

--- a/charts/docreader/templates/_helpers.tpl
+++ b/charts/docreader/templates/_helpers.tpl
@@ -102,6 +102,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{ default (printf "%s-postgresql" .Release.Name) }}
 {{- end }}
 
+{{/* DB Migrations Job Name */}}
+{{- define "docreader.migration" -}}
+{{ default (printf "%s-db-migration-job" .Release.Name) }}
+{{- end }}
+
 {{/* User defined docreader environment variables */}}
 {{- define "docreader.envs" -}}
   {{- range $i, $config := .Values.env }}

--- a/charts/docreader/templates/check-values.yaml
+++ b/charts/docreader/templates/check-values.yaml
@@ -1,5 +1,10 @@
 {{/* The purpose of this yaml file is it to check the values file is consistent for some complexe combinations. */}}
 
+{{- /* App Version check */ -}}
+{{- if lt (default .Chart.AppVersion .Values.image.tag) "7.6" }}
+    {{ required "Chart is not compatibile with Docreader version < 7.6\n Please upgrade to version 7.6 or higher" nil }}
+{{- end }}
+
 {{- /* SSL checks */ -}}
 {{- if .Values.config.service.webServer.ssl.enabled }}
     {{- if not .Values.config.service.webServer.ssl.certificatesSecretName }}

--- a/charts/docreader/templates/config.tpl
+++ b/charts/docreader/templates/config.tpl
@@ -141,6 +141,16 @@ service:
         {{- end }}
     {{- end }}
 
+  houseKeeper:
+    enabled: {{ .Values.config.service.houseKeeper.enabled }}
+    {{- if .Values.config.service.houseKeeper.enabled }}
+    beatCadence: {{ .Values.config.service.houseKeeper.beatCadence }}
+    keepFor: {{ .Values.config.service.houseKeeper.keepFor }}
+    sessionApi:
+      enabled: {{ .Values.config.service.houseKeeper.sessionApi.enabled }}
+      keepFor: {{ .Values.config.service.houseKeeper.sessionApi.keepFor | int64 }}
+    {{- end }}
+
   sdkErrorLog:
     enabled: {{ .Values.config.service.sdkErrorLog.enabled }}
     {{- if .Values.config.service.sdkErrorLog.enabled }}

--- a/charts/docreader/templates/db-migration-job.yaml
+++ b/charts/docreader/templates/db-migration-job.yaml
@@ -1,0 +1,72 @@
+{{- if or .Values.config.service.sessionApi.enabled .Values.config.sdk.rfid.chipVerification.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "docreader.migration" . }}
+  labels: {{- include "docreader.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+      labels: {{- include "docreader.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "docreader.serviceAccount" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      restartPolicy: Never
+      containers:
+        - name: {{ include "docreader.migration" . }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - pipenv
+            - run
+            - python
+            - src/main.py
+            - migrate
+          env:
+            {{- include "docreader.envs" . | indent 10 }}
+            {{- if and (not .Values.postgresql.enabled) .Values.config.service.database.connectionStringSecretName }}
+            - name: SQL_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "docreader.db.credentials.secret" . }}
+                  key: SQL_CONNECTION_STRING
+            {{- end }}
+          volumeMounts:
+            - name: docreader-config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+      volumes:
+        - name: docreader-config
+          configMap:
+            name: {{ include "docreader.config.name" . }}
+{{- end }}

--- a/charts/docreader/templates/deployment.yaml
+++ b/charts/docreader/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /api/ping
+              path: /api/healthz
               port: docreader
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS
@@ -69,7 +69,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /api/readiness
+              path: /api/readyz
               port: docreader
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS
@@ -85,7 +85,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: /api/readiness
+              path: /api/readyz
               port: docreader
               {{- if .Values.config.service.webServer.ssl.enabled }}
               scheme: HTTPS

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -82,7 +82,7 @@ licenseSecretName: ~
 config:
   sdk:
     systemInfo:
-      # Returns system information in the /api/ping response and in the /api/process response.
+      # Returns system information in the /api/healthz response and in the /api/process response.
       returnSystemInfo: true
 
     rfid:

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -224,6 +224,17 @@ config:
           storageClassName: ~
           existingClaim: ~
 
+    # Housekeeper configuration, for the cases when needs to have automatic cleanup of the data
+    # The housekeeper is responsible for cleaning up the data in the storage and database
+    # By default housekeeper is disabled
+    houseKeeper:
+      enabled: false
+      beatCadence: 10
+      keepFor: 14400
+      sessionApi:
+        enabled: false
+        keepFor: 31536000
+
     sdkErrorLog:
       enabled: false
       location:


### PR DESCRIPTION
## Docreader changes summary

Change probes:
- liveness: /api/ping ➝ /api/healthz
- readiness: /api/readiness ➝ /api/readyz
- startup: /api/readiness ➝ /api/readyz

Hosekeeper:
- support for Housekeeper configuration

Migrations:
- add Kubernetes Job for SQL migrations