### PR TITLE
Add SDK Error Log support for Docreader

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,8 +3,8 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 1.2.3
-appVersion: 7.4.293365.1641
+version: 1.3.0
+appVersion: 7.5.305955.1847
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -187,6 +187,11 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 | `config.service.webServer.port`                           | Port server binding                                                               | `8080`                                                        |
 | `config.service.webServer.workers`                        | Number of workers per pod                                                         | `1`                                                           |
 | `config.service.webServer.timeout`                        | Number of seconds for the worker to process the request                           | `30`                                                          |
+| `config.service.webServer.maxRequests`                    | The maximum number of requests a worker will process before restarting            | `0`                                                           |
+| `config.service.webServer.maxRequestsJitter`              | The maximum jitter to add to the `maxRequests` setting                            | `0`                                                           |
+| `config.service.webServer.gracefulTimeout`                | Timeout for graceful workers restart                                              | `30`                                                          |
+| `config.service.webServer.keepalive`                      | The number of seconds to wait for requests on a Keep-Alive connection             | `0`                                                           |
+| `config.service.webServer.workerConnections`              | The maximum number of simultaneous clients                                        | `1000`                                                        |
 | `config.service.webServer.demoApp.enabled`                | Serve a demo web app                                                              | `true`                                                        |
 | `config.service.webServer.demoApp.webComponent.enabled`   | Whether to enable Web Component                                                   | `false`                                                       |
 | `config.service.webServer.cors.origins`                   | Origin, allowed to use API                                                        | `*`                                                           |
@@ -250,6 +255,21 @@ A major chart version change (like v0.1.2 -> v1.0.0) indicates that there is an 
 | `config.service.sessionApi.transactions.persistence.size`             | The size of Session API logs data Persistent Volume storage Class                                  | `10Gi`                                       |
 | `config.service.sessionApi.transactions.persistence.storageClassName` | The Session API logs data Persistent Volume storage Class                                          | `""`                                         |
 | `config.service.sessionApi.transactions.persistence.existingClaim`    | Name of the existing Persistent Volume Claim                                                       | `""`                                         |
+
+
+## SDK Error Logs parameters
+| Parameter                                                 | Description                                                                             | Default                         |
+|-----------------------------------------------------------|-----------------------------------------------------------------------------------------|---------------------------------|
+| `config.service.sdkErrorLog.enabled`                      | Whether to enable SDK Error Log                                                         | `false`                         |
+| `config.service.sdkErrorLog.location.folder`              | The SDK Error Log folder name in case of `fs` storage type                              | `/app/docreader-errors/sdk`     |
+| `config.service.sdkErrorLog.location.bucket`              | The SDK Error Log bucket name in case of `s3`/`gcs` storage type                        | `docreader-errors`              |
+| `config.service.sdkErrorLog.location.container`           | The SDK Error Log storage container name in case of `az` storage type                   | `docreader-errors`              |
+| `config.service.sdkErrorLog.location.prefix`              | The SDK Error Log prefix path in the `bucket/container`                                 | `sdk`                           |
+| `config.service.sdkErrorLog.persistence.enabled`          | Whether to enable SDK Error Log persistence (Applicable only for the `fs` storage type) | `false`                         |
+| `config.service.sdkErrorLog.persistence.accessMode`       | The SDK Error Log data Persistence access mode                                          | `ReadWriteMany`                 |
+| `config.service.sdkErrorLog.persistence.size`             | The size of SDK Error Log data Persistent Volume storage                                | `10Gi`                          |
+| `config.service.sdkErrorLog.persistence.storageClassName` | The SDK Error Log data Persistent Volume storage Class Name                             | `""`                            |
+| `config.service.sdkErrorLog.persistence.existingClaim`    | Name of the existing Persistent Volume Claim                                            | `""`                            |
 
 
 > [!NOTE]

--- a/charts/docreader/templates/_helpers.tpl
+++ b/charts/docreader/templates/_helpers.tpl
@@ -125,6 +125,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{/* SDK Error Log volume claim */}}
+{{- define "docreader.sdkErrorLog.pvc" -}}
+{{- if .Values.config.service.sdkErrorLog.persistence.existingClaim -}}
+{{ .Values.config.service.sdkErrorLog.persistence.existingClaim }}
+{{- else -}}
+{{ .Release.Name }}-sdk-error-log
+{{- end -}}
+{{- end -}}
+
 {{/* Docreader RFID PKD PA volume claim */}}
 {{- define "docreader.rfid.pkd.pvc" -}}
 {{- if .Values.config.sdk.rfid.persistence.existingClaim -}}

--- a/charts/docreader/templates/config.tpl
+++ b/charts/docreader/templates/config.tpl
@@ -20,6 +20,11 @@ service:
     port: {{ .Values.config.service.webServer.port }}
     workers: {{ .Values.config.service.webServer.workers }}
     timeout: {{ .Values.config.service.webServer.timeout }}
+    maxRequests: {{ .Values.config.service.webServer.maxRequests }}
+    maxRequestsJitter: {{ .Values.config.service.webServer.maxRequestsJitter }}
+    gracefulTimeout: {{ .Values.config.service.webServer.gracefulTimeout }}
+    keepalive: {{ .Values.config.service.webServer.keepalive }}
+    workerConnections: {{ .Values.config.service.webServer.workerConnections }}
     demoApp:
       enabled: {{ .Values.config.service.webServer.demoApp.enabled }}
       {{- if .Values.config.service.webServer.demoApp.enabled }}
@@ -133,5 +138,22 @@ service:
         {{- if eq .Values.config.service.storage.type "fs" }}
         folder: {{ quote .Values.config.service.sessionApi.transactions.location.folder }}
         {{- end }}
+    {{- end }}
+
+  sdkErrorLog:
+    enabled: {{ .Values.config.service.sdkErrorLog.enabled }}
+    {{- if .Values.config.service.sdkErrorLog.enabled }}
+    location:
+      {{- if or (eq .Values.config.service.storage.type "s3") (eq .Values.config.service.storage.type "gcs") }}
+      bucket: {{ quote .Values.config.service.sdkErrorLog.location.bucket }}
+      prefix: {{ quote .Values.config.service.sdkErrorLog.location.prefix }}
+      {{- end }}
+      {{- if eq .Values.config.service.storage.type "az" }}
+      container: {{ quote .Values.config.service.sdkErrorLog.location.container }}
+      prefix: {{ quote .Values.config.service.sdkErrorLog.location.prefix }}
+      {{- end }}
+      {{- if eq .Values.config.service.storage.type "fs" }}
+      folder: {{ quote .Values.config.service.sdkErrorLog.location.folder }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/docreader/templates/deployment.yaml
+++ b/charts/docreader/templates/deployment.yaml
@@ -154,6 +154,10 @@ spec:
             - name: session-api-transactions
               mountPath: {{ quote .Values.config.service.sessionApi.transactions.location.folder }}
             {{- end }}
+            {{- if and (eq .Values.config.service.storage.type "fs") .Values.config.service.sdkErrorLog.enabled .Values.config.service.sdkErrorLog.persistence.enabled }}
+            - name: sdk-error-log
+              mountPath: {{ quote .Values.config.service.sdkErrorLog.location.folder }}
+            {{- end }}
             {{- if and .Values.config.sdk.rfid.enabled .Values.config.sdk.rfid.persistence.enabled }}
             - name: rfid-pkd
               mountPath: {{ quote .Values.config.sdk.rfid.pkdPaPath }}
@@ -190,6 +194,11 @@ spec:
         - name: session-api-transactions
           persistentVolumeClaim:
             claimName: {{ template "docreader.sessionApi.transactions.pvc" . }}
+        {{- end }}
+        {{- if and (eq .Values.config.service.storage.type "fs") .Values.config.service.sdkErrorLog.enabled .Values.config.service.sdkErrorLog.persistence.enabled }}
+        - name: sdk-error-log
+          persistentVolumeClaim:
+            claimName: {{ template "docreader.sdkErrorLog.pvc" . }}
         {{- end }}
         {{- if and .Values.config.sdk.rfid.enabled .Values.config.sdk.rfid.persistence.enabled }}
         - name: rfid-pkd

--- a/charts/docreader/templates/sdk-error-pvc.yaml
+++ b/charts/docreader/templates/sdk-error-pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and (eq .Values.config.service.storage.type "fs") .Values.config.service.sdkErrorLog.enabled .Values.config.service.sdkErrorLog.persistence.enabled (not .Values.config.service.sdkErrorLog.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "docreader.sdkErrorLog.pvc" . }}
+  labels: {{- include "docreader.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.config.service.sdkErrorLog.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.config.service.sdkErrorLog.persistence.size | quote }}
+  {{- if .Values.config.service.sdkErrorLog.persistence.storageClassName }}
+  {{- if (eq "-" .Values.config.service.sdkErrorLog.persistence.storageClassName) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ quote .Values.config.service.sdkErrorLog.persistence.storageClassName }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -101,6 +101,11 @@ config:
       port: 8080
       workers: 1
       timeout: 30
+      maxRequests: 0
+      maxRequestsJitter: 0
+      gracefulTimeout: 30
+      keepalive: 0
+      workerConnections: 1000
 
       demoApp:
         enabled: true
@@ -214,6 +219,22 @@ config:
           size: 10Gi
           storageClassName: ~
           existingClaim: ~
+
+    sdkErrorLog:
+      enabled: false
+      location:
+        folder: "/app/docreader-errors/sdk"
+        # bucket: "docreader-errors" # storage type s3/gcs
+        # container: "docreader-errors" # storage type az
+        prefix: "sdk"
+      # Persistence is only applicable for the fs storage type
+      persistence:
+        # Enable persistent volume for storing transactions data
+        enabled: false
+        accessMode: ReadWriteMany
+        size: 10Gi
+        storageClassName: ~
+        existingClaim: ~
 
 env: []
 # - name: ""


### PR DESCRIPTION
## Summary

- Add SDK Error Log support for `Docreader` Helm Chart
- Bumb app version to `7.5.305955.1847`
- Extended Webserver configuration