### PR TITLE
Make ingress more flexible in defining paths

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.0.7
+version: 1.0.8
 appVersion: 3.1.3
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/idv/templates/NOTES.txt
+++ b/charts/idv/templates/NOTES.txt
@@ -22,7 +22,11 @@ MIND: Metrics collection is configured to external statsd deployment
 {{- $paths := .Values.ingress.paths -}}
 {{- range $host := .Values.ingress.hosts }}
   {{- range $p := $paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ tpl $host $ }}{{ tpl $p $ }}
+    {{- if kindIs "map" $p }}
+      http{{ if $.Values.ingress.tls }}s{{ end }}://{{ tpl $host $ }}{{ tpl $p.path $ }}
+    {{- else }}
+      http{{ if $.Values.ingress.tls }}s{{ end }}://{{ tpl $host $ }}{{ tpl $p $ }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.api.service.type }}

--- a/charts/idv/templates/ingress.yaml
+++ b/charts/idv/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := printf "%s-api" (include "idv.fullname" .) -}}
-{{- $servicePort := .Values.api.service.port -}}
+{{- $defaultServiceName := printf "%s-api" (include "idv.fullname" .) -}}
+{{- $defaultServicePort := .Values.api.service.port -}}
 {{- $paths := .Values.ingress.paths -}}
 {{- $pathType := .Values.ingress.pathType | default "Prefix" -}}
 apiVersion: networking.k8s.io/v1
@@ -22,28 +22,60 @@ spec:
       http:
         paths:
         {{- range $p := $paths }}
+          {{- if kindIs "map" $p }}
+          - path: {{ tpl $p.path $ }}
+            pathType: {{ $p.pathType | default $pathType }}
+            backend:
+              service:
+                {{- if $p.action }}
+                name: {{ $p.action }}
+                port:
+                  name: use-annotation
+                {{- else }}
+                name: {{ $p.service.name | default $defaultServiceName }}
+                port:
+                  number: {{ $p.service.port | default $defaultServicePort }}
+                {{- end }}
+          {{- else }}
           - path: {{ tpl $p $ }}
             pathType: {{ $pathType }}
             backend:
               service:
-                name: {{ $serviceName }}
+                name: {{ $defaultServiceName }}
                 port:
-                  number: {{ $servicePort }}
-        {{- end -}}
+                  number: {{ $defaultServicePort }}
+          {{- end }}
+        {{- end }}
     {{- end -}}
   {{- else }}
     - http:
         paths:
         {{- range $p := $paths }}
+          {{- if kindIs "map" $p }}
+          - path: {{ tpl $p.path $ }}
+            pathType: {{ $p.pathType | default $pathType }}
+            backend:
+              service:
+                {{- if $p.action }}
+                name: {{ $p.action }}
+                port:
+                  name: use-annotation
+                {{- else }}
+                name: {{ $p.service.name | default $defaultServiceName }}
+                port:
+                  number: {{ $p.service.port | default $defaultServicePort }}
+                {{- end }}
+          {{- else }}
           - path: {{ tpl $p $ }}
             pathType: {{ $pathType }}
             backend:
               service:
-                name: {{ $serviceName }}
+                name: {{ $defaultServiceName }}
                 port:
-                  number: {{ $servicePort }}
-        {{- end -}}
-  {{- end -}}
+                  number: {{ $defaultServicePort }}
+          {{- end }}
+        {{- end }}
+  {{- end }}
   {{- with .Values.ingress.tls }}
   tls: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/idv/values.yaml
+++ b/charts/idv/values.yaml
@@ -415,13 +415,19 @@ env:
 ingress:
   enabled: false
   # The Ingress Class for the web Ingress (used only with Kubernetes v1.19 and above)
-  # className: ""
+  className: ""
   annotations: {}
   # The hostnames or hosts configuration for the web Ingress
   hosts: []
     # - idv.domain.com
   paths: []
     # - /
+    # - path: /api
+    #   service:
+    #     name: my-api-service
+    #     port: 8080
+    # - path: /metrics
+    #   action: metrics-block
   pathType: Prefix
   # TLS configuration for the IDV Ingress
   tls: []


### PR DESCRIPTION
## Summary

This PR enhances the Ingress template to support both legacy and structured path definitions in `values.yaml`.

## Details

- **Backward compatibility**: Existing charts using simple string paths (e.g. - /) continue to work without modification.
- **New functionality**: Paths can now be defined as maps with `path`, `service`, and/or `action` fields.

Example service override:
```
- path: /api
  service:
    name: my-api-service
    port: 8080
```

Example ALB action:
```
- path: /metrics
  action: metrics-block
```

- **Annotations**: ALB actions (e.g. fixed-response, redirects) are configured via annotations and referenced in paths using the `action` field.
- **NOTES.txt updated**: Now handles both string and map path definitions when rendering example URLs.

## Impact

- Users can block or redirect paths at the ALB level without exposing them to backend services.
- Chart remains compatible with existing values files.
- Provides a more flexible and future‑proof Ingress configuration.