### PR TITLE
Add Network Policy support for IDV Helm chart

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.0.8
-appVersion: 3.1.3
+version: 1.0.9
+appVersion: 3.1.5
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/idv/README.md
+++ b/charts/idv/README.md
@@ -330,6 +330,10 @@ helm upgrade my-release regulaforensics/idv
 | `ingress.paths`                                           | Ingress paths                                     | `[]`                              |
 | `ingress.pathType`                                        | Ingress path type                                 | `Prefix`                          |
 | `ingress.tls`                                             | Ingress TLS entries                               | `[]`                              |
+| `networkPolicy.enabled`                                   | Enable NetworkPolicy                              | `false`                           |
+| `networkPolicy.annotations`                               | NetworkPolicy annotations                         | `{}`                              |
+| `networkPolicy.ingress`                                   | Set NetworkPolicy Ingress rules                   | `{}`                              |
+| `networkPolicy.egress`                                    | Set NetworkPolicy Egress rules                    | `{}`                              |
 | `serviceAccount.create`                                   | Create service account                            | `true`                            |
 | `serviceAccount.annotations`                              | Service account annotations                       | `{}`                              |
 | `serviceAccount.name`                                     | Service account name override                     | `""`                              |

--- a/charts/idv/templates/networkpolicy.yaml
+++ b/charts/idv/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "idv.fullname" . }}
+  labels:
+    {{- include "idv.labels" . | nindent 4 }}
+  {{- with .Values.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  policyTypes:
+    {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkPolicy.egress }}
+    - Egress
+    {{- end }}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.networkPolicy.ingress }}
+  ingress: {{- toYaml .Values.networkPolicy.ingress | nindent 4 -}}
+  {{- end -}}
+  {{- if .Values.networkPolicy.egress }}
+  egress: {{- toYaml .Values.networkPolicy.egress | nindent 4 -}}
+  {{- end -}}
+{{- end }}

--- a/charts/idv/values.yaml
+++ b/charts/idv/values.yaml
@@ -435,6 +435,37 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+networkPolicy:
+  enabled: false
+  annotations: {}
+  ingress: {}
+    # # allow ingress traffic from local namespace only
+    # - from:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: put-your-namespace-here
+  egress: {}
+    # # allow egress traffic to local namespace only
+    # - to:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: put-your-namespace-here
+    # # allow DNS resolution
+    # - ports:
+    #   - protocol: UDP
+    #     port: 53
+    # # allow traffic to lic.regulaforensics.com and lic2.regulaforensics.com
+    # - ports:
+    #   - protocol: TCP
+    #     port: 443
+    #   to:
+    #     - ipBlock:
+    #         cidr: 3.33.212.24/32
+    #     - ipBlock:
+    #         cidr: 15.197.254.180/32
+    #     - ipBlock:
+    #         cidr: 34.96.77.73/32
+
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
## Summary

This PR introduces `NetworkPolicy` support to the `IDV` Helm chart, enabling users to define fine-grained **ingress** and **egress** rules for Pods deployed with this chart. By default, the chart will not enforce any restrictions, but users can opt-in to apply custom policies.