### PR TITLE
fix(idv): add KEDA ScaledObject fallback to prevent zero-replica deadlock

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.9.1
+version: 1.9.2
 appVersion: 3.5.1
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.9.2
+version: 1.9.4
 appVersion: 3.5.1
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/idv/README.md
+++ b/charts/idv/README.md
@@ -211,8 +211,15 @@ helm upgrade my-release regulaforensics/idv
 | `api.autoscaling.targetCPUUtilizationPercentage`          | Target CPU utilization percent                    | `80`                              |
 | `api.autoscaling.targetMemoryUtilizationPercentage`       | Target memory utilization percent                 | `80`                              |
 | `api.autoscaling.keda.enabled`                            | Enable KEDA for API                               | `false`                           |
+| `api.autoscaling.keda.minReplicaCount`                    | KEDA minimum replica count for API                | `1`                               |
+| `api.autoscaling.keda.maxReplicaCount`                    | KEDA maximum replica count for API                | `100`                             |
+| `api.autoscaling.keda.cooldownPeriod`                     | KEDA cooldown period (seconds) for API            | `300`                             |
+| `api.autoscaling.keda.pollingInterval`                    | KEDA polling interval (seconds) for API           | `30`                              |
 | `api.autoscaling.keda.triggers`                           | KEDA triggers for API                             | `[]`                              |
 | `api.autoscaling.keda.TriggerAuthentication`              | KEDA TriggerAuthentication for API                | `null`                            |
+| `api.autoscaling.keda.fallback`                           | KEDA fallback config when metrics unavailable     | `null`                            |
+| `api.autoscaling.keda.fallback.failureThreshold`          | Errors before fallback activates                  | `3`                               |
+| `api.autoscaling.keda.fallback.replicas`                  | Replica count during fallback                     | `1`                               |
 | `api.podDisruptionBudget.enabled`                         | Enable PDB for API                                | `false`                           |
 | `api.podDisruptionBudget.config.maxUnavailable`           | PDB maxUnavailable for API                        | `~`                               |
 | `api.podDisruptionBudget.config.minAvailable`             | PDB minAvailable for API                          | `1`                               |
@@ -246,8 +253,15 @@ helm upgrade my-release regulaforensics/idv
 | `workflow.autoscaling.targetCPUUtilizationPercentage`     | Workflow target CPU percent                       | `80`                              |
 | `workflow.autoscaling.targetMemoryUtilizationPercentage`  | Workflow target memory percent                    | `80`                              |
 | `workflow.autoscaling.keda.enabled`                       | Enable KEDA for Workflow                          | `false`                           |
+| `workflow.autoscaling.keda.minReplicaCount`               | KEDA minimum replica count for Workflow           | `1`                               |
+| `workflow.autoscaling.keda.maxReplicaCount`               | KEDA maximum replica count for Workflow           | `100`                             |
+| `workflow.autoscaling.keda.cooldownPeriod`                | KEDA cooldown period (seconds) for Workflow       | `300`                             |
+| `workflow.autoscaling.keda.pollingInterval`               | KEDA polling interval (seconds) for Workflow      | `30`                              |
 | `workflow.autoscaling.keda.triggers`                      | KEDA triggers for Workflow                        | `[]`                              |
 | `workflow.autoscaling.keda.TriggerAuthentication`         | KEDA TriggerAuthentication for Workflow           | `null`                            |
+| `workflow.autoscaling.keda.fallback`                      | KEDA fallback config when metrics unavailable     | `null`                            |
+| `workflow.autoscaling.keda.fallback.failureThreshold`     | Errors before fallback activates                  | `3`                               |
+| `workflow.autoscaling.keda.fallback.replicas`             | Replica count during fallback                     | `1`                               |
 | `workflow.podDisruptionBudget.enabled`                    | Enable PDB for Workflow                           | `false`                           |
 | `workflow.podDisruptionBudget.config.maxUnavailable`      | PDB maxUnavailable for Workflow                   | `~`                               |
 | `workflow.podDisruptionBudget.config.minAvailable`        | PDB minAvailable for Workflow                     | `1`                               |

--- a/charts/idv/templates/scaledobject-api.yaml
+++ b/charts/idv/templates/scaledobject-api.yaml
@@ -12,6 +12,11 @@ spec:
   maxReplicaCount: {{ .Values.api.autoscaling.keda.maxReplicaCount | default 100 }}
   cooldownPeriod: {{ .Values.api.autoscaling.keda.cooldownPeriod | default 300 }}
   pollingInterval: {{ .Values.api.autoscaling.keda.pollingInterval | default 30 }}
+  {{- if .Values.api.autoscaling.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .Values.api.autoscaling.keda.fallback.failureThreshold | default 3 }}
+    replicas: {{ .Values.api.autoscaling.keda.fallback.replicas | default 1 }}
+  {{- end }}
   triggers:
   {{- range .Values.api.autoscaling.keda.triggers }}
   - type: {{ .type }}

--- a/charts/idv/templates/scaledobject-workflow.yaml
+++ b/charts/idv/templates/scaledobject-workflow.yaml
@@ -12,6 +12,11 @@ spec:
   maxReplicaCount: {{ .Values.workflow.autoscaling.keda.maxReplicaCount | default 100 }}
   cooldownPeriod: {{ .Values.workflow.autoscaling.keda.cooldownPeriod | default 300 }}
   pollingInterval: {{ .Values.workflow.autoscaling.keda.pollingInterval | default 30 }}
+  {{- if .Values.workflow.autoscaling.keda.fallback }}
+  fallback:
+    failureThreshold: {{ .Values.workflow.autoscaling.keda.fallback.failureThreshold | default 3 }}
+    replicas: {{ .Values.workflow.autoscaling.keda.fallback.replicas | default 1 }}
+  {{- end }}
   triggers:
   {{- range .Values.workflow.autoscaling.keda.triggers }}
   - type: {{ .type }}

--- a/charts/idv/templates/triggerauthentication-api.yaml
+++ b/charts/idv/templates/triggerauthentication-api.yaml
@@ -6,10 +6,16 @@ metadata:
   labels:
     {{- include "idv.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.api.autoscaling.keda.TriggerAuthentication.secretTargetRef }}
   secretTargetRef:
   {{- range .Values.api.autoscaling.keda.TriggerAuthentication.secretTargetRef }}
   - parameter: {{ .parameter }}
     name: {{ .name }}
     key: {{ .key }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.api.autoscaling.keda.TriggerAuthentication.podIdentity }}
+  podIdentity:
+    provider: {{ .Values.api.autoscaling.keda.TriggerAuthentication.podIdentity.provider }}
   {{- end }}
 {{- end }}

--- a/charts/idv/values.yaml
+++ b/charts/idv/values.yaml
@@ -56,6 +56,11 @@ api:
     # Either HPA or KEDA can be enabled at a time for autoscaling
     keda:
       enabled: false
+      # KEDA-specific replica count settings (override autoscaling.minReplicas/maxReplicas)
+      # minReplicaCount: 1
+      # maxReplicaCount: 10
+      # cooldownPeriod: 300
+      # pollingInterval: 30
       triggers: []
       TriggerAuthentication: null
       # Optional: fallback behavior when the metric source is unavailable
@@ -119,6 +124,11 @@ workflow:
     # Either HPA or KEDA can be enabled at a time for autoscaling
     keda:
       enabled: false
+      # KEDA-specific replica count settings (override autoscaling.minReplicas/maxReplicas)
+      # minReplicaCount: 1
+      # maxReplicaCount: 100
+      # cooldownPeriod: 300
+      # pollingInterval: 30
       triggers: []
       TriggerAuthentication: null
       # Optional: fallback behavior when the metric source is unavailable
@@ -422,7 +432,7 @@ config:
       dsn: null
       environment: null
 
-env:
+env: []
   # The 'idv' secret has to be preinstalled in the same namespace as the IDV Coordinator.
   # Uncomment the following lines to use secrets for sensitive configuration values.
   # - name: IDV_CONFIG__MONGO__URL
@@ -636,18 +646,64 @@ statsd:
           method: "$2"
           url_rule: "$3"
           status: "$4"
+
       - match: "idv.(.*)_http_status_(.*)_total"
         name: "idv_${1}_http_request_total"
         match_type: regex
         labels:
           service: "$1"
           status: "$2"
+
+      - match: "idv.(mongo|vector_db|text_search|storage)_([^_]+)_(.+)_duration"
+        name: "idv_${1}_duration"
+        match_type: regex
+        observer_type: summary
+        summary_options:
+          quantiles:
+            - quantile: 0.5
+              error: 0.05
+            - quantile: 0.9
+              error: 0.02
+            - quantile: 0.95
+              error: 0.01
+            - quantile: 0.99
+              error: 0.001
+        labels:
+          type: "$1"
+          repo: "$2"
+          operation: "$3"
+
+      - match: "idv.(mongo|vector_db|text_search|storage)_([^_]+)_(.+)_success_count"
+        name: "idv_${1}_success_count"
+        match_type: regex
+        labels:
+          type: "$1"
+          repo: "$2"
+          operation: "$3"
+
+      - match: "idv.(mongo|vector_db|text_search|storage)_([^_]+)_(.+)_error_count"
+        name: "idv_${1}_error_count"
+        match_type: regex
+        labels:
+          type: "$1"
+          repo: "$2"
+          operation: "$3"
+
+      - match: "idv.(mongo|vector_db|text_search|storage)_([^_]+)_(.+)_count"
+        name: "idv_${1}_total"
+        match_type: regex
+        labels:
+          type: "$1"
+          repo: "$2"
+          operation: "$3"
+
       - match: "idv.(.*)_(.*)_duration"
         name: "idv_${1}_duration"
         match_type: regex
         labels:
           service: "$1"
           operation: "$2"
+
       - match: "idv.(.*)_(.*)_(.*)_condition_eval_count"
         name: "idv_workflow_step_condition_eval_count"
         match_type: regex
@@ -655,24 +711,28 @@ statsd:
           workflow_id: "$1"
           condition: "$2"
           result: "$3"
+
       - match: "idv.(.*)_(.*)_error_count"
         name: "idv_error"
         match_type: regex
         labels:
           service: "$1"
           operation: "$2"
+
       - match: "idv.(.*)_(.*)_success_count"
         name: "idv_${1}_success_count"
         match_type: regex
         labels:
           service: "$1"
           operation: "$2"
+
       - match: "idv.(.*)_(.*)_error_count"
         name: "idv_${1}_error_count"
         match_type: regex
         labels:
           service: "$1"
           operation: "$2"
+
       - match: "idv.(.*)_(.*)_count"
         name: "idv_${1}_total"
         match_type: regex

--- a/charts/idv/values.yaml
+++ b/charts/idv/values.yaml
@@ -58,6 +58,14 @@ api:
       enabled: false
       triggers: []
       TriggerAuthentication: null
+      # Optional: fallback behavior when the metric source is unavailable
+      # (e.g. RabbitMQ queue not yet created in ephemeral PR environments).
+      # KEDA will hold `replicas` replicas after `failureThreshold` consecutive errors,
+      # then resume normal scaling once the metric source recovers.
+      # fallback:
+      #   failureThreshold: 3
+      #   replicas: 1
+
   # API pod disruption budget
   podDisruptionBudget:
     enabled: false
@@ -113,6 +121,13 @@ workflow:
       enabled: false
       triggers: []
       TriggerAuthentication: null
+      # Optional: fallback behavior when the metric source is unavailable
+      # (e.g. RabbitMQ queue not yet created in ephemeral PR environments).
+      # KEDA will hold `replicas` replicas after `failureThreshold` consecutive errors,
+      # then resume normal scaling once the metric source recovers.
+      # fallback:
+      #   failureThreshold: 3
+      #   replicas: 1
 
   # Workflow pod disruption budget
   podDisruptionBudget:


### PR DESCRIPTION
## Problem

When KEDA cannot retrieve metrics from a trigger source (e.g. RabbitMQ queue `rc-pr-XXXX-event` not yet created in ephemeral PR environments), `ScaledObject` without a `fallback` block is unable to make a scaling decision. With `minReplicaCount: 0` this results in the deployment staying at **0 replicas for 5+ minutes** until the metric source becomes available.

Observed in production:
```
ERROR scale_handler error getting scale decision
  scaledObject.Name: idv-workflow
  error: "error inspecting RabbitMQ: Exception (404) Reason: NOT_FOUND - no queue 'rc-pr-2223-event' in vhost '/'"
```

## Solution

Add optional `fallback` support to both `scaledobject-workflow.yaml` and `scaledobject-api.yaml` templates. When configured, KEDA will hold a fixed number of replicas after N consecutive metric errors, then resume normal autoscaling once the metric source recovers.

### Usage

```yaml
workflow:
  autoscaling:
    keda:
      enabled: true
      minReplicaCount: 0
      fallback:
        failureThreshold: 3   # consecutive errors before fallback activates
        replicas: 1           # replicas to hold during fallback
      triggers:
        - type: rabbitmq
          ...
```

## Changes

- `templates/scaledobject-workflow.yaml` — add optional `fallback` block
- `templates/scaledobject-api.yaml` — add optional `fallback` block  
- `values.yaml` — document `fallback` option with commented example
- `Chart.yaml` — bump version `1.9.1` → `1.9.2`

## Backward compatibility

`fallback` is opt-in (rendered only when `keda.fallback` is set in values). No existing deployments are affected.