### PR TITLE
IDV: Bump chart version to 1.11.0 and appVersion to 3.7.0-0

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.10.1
-appVersion: 3.6.1
+version: 1.11.0
+appVersion: 3.7.0-0
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:


### PR DESCRIPTION
# Description

Release IDV chart for app version `3.7.0-0`.

- `charts/idv/Chart.yaml`: `version` `1.10.1` → `1.11.0`, `appVersion` `3.6.1` → `3.7.0-0`

# Change type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Add/Update documentation

# Notes

Chart version bumped (minor) to reflect the new app release.
