### PR TITLE
fix: correct idv appVersion 3.7.0-0 → 3.7.0

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: idv
 home: https://idv.regula.app/
 version: 1.11.0
-appVersion: 3.7.0-0
+appVersion: 3.7.0
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.11.0
+version: 1.11.1
 appVersion: 3.7.0
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg


### PR DESCRIPTION
# Description

Fix incorrect `appVersion` in the IDV chart and bump chart version to pass CI version increment check.

Changed files:
- `charts/idv/Chart.yaml` — `appVersion: 3.7.0-0` → `3.7.0`
- `charts/idv/Chart.yaml` — `version: 1.11.0` → `1.11.1`

# Ticket link

https://redmine.regulaforensics.com/issues/58075

# Change type

- [x] Bug fix

# Notes

`appVersion` was mistakenly set to `3.7.0-0` instead of the correct release tag `3.7.0`. Chart version bumped from `1.11.0` to `1.11.1`.