### PR TITLE
Docreader: Bump chart version to 2.11.0 and appVersion to 9.5

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,8 +3,8 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 2.10.1
-appVersion: 9.4.319820.2195
+version: 2.11.0
+appVersion: 9.5.320525.2224
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/docreader/templates/config.tpl
+++ b/charts/docreader/templates/config.tpl
@@ -20,11 +20,12 @@ sdk:
       enabled: {{ .Values.config.sdk.mDL.sessionVerification.enabled }}
 
   {{- if .Values.config.sdk.processParam }}
+
   processParam:
     {{- toYaml .Values.config.sdk.processParam | nindent 4 }}
   {{- end }}
-
   {{- if .Values.config.sdk.requestLimits }}
+
   requestLimits:
     {{- toYaml .Values.config.sdk.requestLimits | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
## Description

- Bump chart version from `2.10.1` to `2.11.0`
- Update appVersion to `9.5.320525.2224` (production release)
- Fix formatting in `config.tpl`: add blank lines between `processParam` and `requestLimits` sections for consistency with `mDL` configuration