### PR TITLE
IDV: Bump chart version to 1.11.2 and appVersion to 3.7.1

### DIFF
--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.11.1
-appVersion: 3.7.0
+version: 1.11.2
+appVersion: 3.7.1
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:


### PR DESCRIPTION
## Description

Promotes the idv chart to version `1.11.2` with appVersion updated from `3.7.0` to `3.7.1`, reflecting the new application release.