### PR TITLE
Bump chart versions and add TLS/KEDA enhancements

### DIFF
--- a/charts/docreader/Chart.yaml
+++ b/charts/docreader/Chart.yaml
@@ -3,8 +3,8 @@
 apiVersion: v2
 name: docreader
 home: https://api.regulaforensics.com/
-version: 2.11.0
-appVersion: 9.5.320525.2224
+version: 2.12.0
+appVersion: 9.5.321120.2224
 description: Fast and accurate data extraction from identity documents. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg
 keywords:

--- a/charts/docreader/README.md
+++ b/charts/docreader/README.md
@@ -157,6 +157,31 @@ env:
         key: config-key
 ```
 
+## In-cluster TLS (trusted CA bundle)
+
+When connecting to backends (MongoDB, S3/object storage, OpenSearch) over TLS that is signed by
+an internal/private CA, the application must trust that CA. Rather than rebuilding the image, set
+`tls.trustedCABundle.configMapName` to a ConfigMap containing a PEM CA bundle (for example one
+produced by [cert-manager trust-manager](https://cert-manager.io/docs/trust/trust-manager/),
+combining your private CA with the public CAs). The chart then:
+
+- mounts the bundle as a directory at `tls.trustedCABundle.mountPath` (use this path for clients
+  that take an explicit CA file, e.g. a MongoDB connection string `…&tls=true&tlsCAFile=/etc/regula/tls/ca-bundle.pem`);
+- overlays the bundle onto the image's CA store file(s) listed in `tls.trustedCABundle.caStorePaths`
+  (the Python `certifi` store by default) so clients that read a bundled store (boto3/S3,
+  opensearch-py) trust it; and
+- sets `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, and `AWS_CA_BUNDLE` environment variables as an
+  additional layer of coverage.
+
+```yaml
+tls:
+  trustedCABundle:
+    configMapName: my-ca-bundle   # ConfigMap with key `ca-bundle.pem`
+```
+
+The feature is disabled by default (`configMapName: ""`) and changes nothing in existing releases.
+`caStorePaths` defaults target this image's layout; update when the image changes Python version.
+
 ## Common parameters
 
 | Parameter                                 | Description                                                                                   | Default                       |
@@ -188,6 +213,10 @@ env:
 | `env`                                     | Additional environment variables (supports value, secretKeyRef, configMapKeyRef)              | `[]`                          |
 | `extraVolumes`                            | Additional Docreader volumes                                                                  | `[]`                          |
 | `extraVolumeMounts`                       | Additional Docreader volume mounts                                                            | `[]`                          |
+| `tls.trustedCABundle.configMapName`       | Name of a ConfigMap holding a CA bundle to trust for in-cluster TLS (e.g. from cert-manager trust-manager). Empty disables the feature | `""`        |
+| `tls.trustedCABundle.key`                 | Key in the ConfigMap that holds the PEM CA bundle                                             | `ca-bundle.pem`               |
+| `tls.trustedCABundle.mountPath`           | Directory the bundle is mounted at (use for e.g. MongoDB `tlsCAFile`)                         | `/etc/regula/tls`             |
+| `tls.trustedCABundle.caStorePaths`        | CA-store file(s) overlaid with the bundle (image-version-dependent; update on Python upgrade)  | `[certifi cacert.pem]`        |
 | `service.type`                            | Kubernetes service type                                                                       | `ClusterIP`                   |
 | `service.port`                            | Kubernetes port where service is exposed                                                      | `80`                          |
 | `service.annotations`                     | Service annotations (can be templated)                                                        | `{}`                          |
@@ -220,6 +249,13 @@ env:
 | `startupProbe.enabled`                    | Enable startupProbe                                                                           | `true`                        |
 | `autoscaling.enabled`                     | Enable autoscaling                                                                            | `false`                       |
 | `autoscaling.keda.enabled`                | Enable KEDA autoscaling                                                                       | `false`                       |
+| `autoscaling.keda.minReplicaCount`        | KEDA minimum replica count                                                                    | `1`                           |
+| `autoscaling.keda.maxReplicaCount`        | KEDA maximum replica count                                                                    | `10`                          |
+| `autoscaling.keda.pollingInterval`        | How frequently (seconds) KEDA polls the triggers                                              | `30`                          |
+| `autoscaling.keda.cooldownPeriod`         | Seconds to wait before scaling in after load drops                                            | `300`                         |
+| `autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling up                        | `180`                         |
+| `autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling down                    | `300`                         |
+| `autoscaling.keda.triggers`               | List of KEDA scaler triggers                                                                  | `[]`                          |
 | `networkPolicy.enabled`                   | Enable NetworkPolicy                                                                          | `false`                       |
 | `networkPolicy.annotations`               | NetworkPolicy annotations                                                                     | `{}`                          |
 | `networkPolicy.ingress`                   | Set NetworkPolicy Ingress rules                                                               | `{}`                          |

--- a/charts/docreader/templates/_helpers.tpl
+++ b/charts/docreader/templates/_helpers.tpl
@@ -164,3 +164,42 @@ app.kubernetes.io/component: db-migration
 {{ .Release.Name }}-rfid-pkd-pa
 {{- end -}}
 {{- end -}}
+
+{{/*
+Optional trusted-CA bundle volume (enabled via tls.trustedCABundle.configMapName).
+*/}}
+{{- define "docreader.caBundle.volumes" -}}
+- name: regula-ca-bundle
+  configMap:
+    name: {{ .Values.tls.trustedCABundle.configMapName }}
+{{- end -}}
+
+{{/*
+Trusted-CA bundle mount: the bundle is mounted as a directory so clients that take an explicit
+CA file path (e.g. MongoDB tlsCAFile) can reference it directly, plus per-CA-store file overlays
+so clients that read a bundled CA store (certifi, botocore) trust it.
+*/}}
+{{- define "docreader.caBundle.volumeMounts" -}}
+- name: regula-ca-bundle
+  mountPath: {{ .Values.tls.trustedCABundle.mountPath }}
+  readOnly: true
+{{- range .Values.tls.trustedCABundle.caStorePaths }}
+- name: regula-ca-bundle
+  mountPath: {{ . }}
+  subPath: {{ $.Values.tls.trustedCABundle.key }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+TLS CA bundle environment variables. Sets SSL_CERT_FILE, REQUESTS_CA_BUNDLE, and AWS_CA_BUNDLE
+so all Python TLS clients trust the mounted bundle regardless of Python/package version.
+*/}}
+{{- define "docreader.caBundle.env" -}}
+- name: SSL_CERT_FILE
+  value: {{ printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key }}
+- name: REQUESTS_CA_BUNDLE
+  value: {{ printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key }}
+- name: AWS_CA_BUNDLE
+  value: {{ printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key }}
+{{- end -}}

--- a/charts/docreader/templates/db-migration-job.yaml
+++ b/charts/docreader/templates/db-migration-job.yaml
@@ -61,6 +61,9 @@ spec:
                   name: {{ template "docreader.db.credentials.secret" . }}
                   key: SQL_CONNECTION_STRING
             {{- end }}
+            {{- if .Values.tls.trustedCABundle.configMapName }}
+            {{- include "docreader.caBundle.env" . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: docreader-config
               mountPath: /app/config.yaml
@@ -69,11 +72,17 @@ spec:
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+          {{- if .Values.tls.trustedCABundle.configMapName }}
+          {{- include "docreader.caBundle.volumeMounts" . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: docreader-config
           configMap:
             name: {{ include "docreader.config.name" . }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tls.trustedCABundle.configMapName }}
+      {{- include "docreader.caBundle.volumes" . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/docreader/templates/deployment.yaml
+++ b/charts/docreader/templates/deployment.yaml
@@ -130,6 +130,9 @@ spec:
                   name: {{ template "docreader.db.credentials.secret" . }}
                   key: SQL_CONNECTION_STRING
             {{- end }}
+            {{- if .Values.tls.trustedCABundle.configMapName }}
+            {{- include "docreader.caBundle.env" . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: docreader-config
               mountPath: /app/config.yaml
@@ -170,6 +173,9 @@ spec:
             {{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
+{{- if .Values.tls.trustedCABundle.configMapName }}
+{{ include "docreader.caBundle.volumeMounts" . | indent 12 }}
 {{- end }}
       volumes:
         - name: docreader-config
@@ -212,4 +218,7 @@ spec:
         {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- if .Values.tls.trustedCABundle.configMapName }}
+{{ include "docreader.caBundle.volumes" . | indent 8 }}
 {{- end }}

--- a/charts/docreader/templates/keda-hpa.yaml
+++ b/charts/docreader/templates/keda-hpa.yaml
@@ -13,6 +13,19 @@ spec:
   maxReplicaCount: {{ .Values.autoscaling.keda.maxReplicaCount | default 10 }}
   pollingInterval: {{ .Values.autoscaling.keda.pollingInterval | default 30 }} 
   cooldownPeriod: {{ .Values.autoscaling.keda.cooldownPeriod | default 300 }}
+  {{- if .Values.autoscaling.keda.advanced }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        {{- if .Values.autoscaling.keda.advanced.scaleUp }}
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds | default 180 }}
+        {{- end }}
+        {{- if .Values.autoscaling.keda.advanced.scaleDown }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds | default 300 }}
+        {{- end }}
+  {{- end }}
   triggers:
 {{- range .Values.autoscaling.keda.triggers }}
   - type: {{ .type }}

--- a/charts/docreader/values.yaml
+++ b/charts/docreader/values.yaml
@@ -313,6 +313,23 @@ env: []
 extraVolumes: []
 extraVolumeMounts: []
 
+# Optional: trust an internal/private CA for in-cluster TLS (e.g. to MongoDB, S3/MinIO,
+# OpenSearch) without rebuilding the image. Point `configMapName` at a ConfigMap (e.g. produced
+# by cert-manager trust-manager) holding a CA bundle under `key`. When set, the chart mounts the
+# bundle at `mountPath`, overlays it onto the image's CA store(s) listed in `caStorePaths`, and
+# sets SSL_CERT_FILE / REQUESTS_CA_BUNDLE / AWS_CA_BUNDLE env vars so all Python TLS clients
+# trust certificates signed by that CA. Disabled by default.
+tls:
+  trustedCABundle:
+    configMapName: ""
+    key: ca-bundle.pem
+    # Directory the bundle is mounted at (use this path for e.g. MongoDB tlsCAFile).
+    mountPath: /etc/regula/tls
+    # CA-store files to overlay with the bundle. Defaults target this image's layout;
+    # update when the image changes Python version.
+    caStorePaths:
+      - /app/.venv/lib/python3.11/site-packages/certifi/cacert.pem
+
 service:
   type: ClusterIP
   port: 80
@@ -479,8 +496,16 @@ autoscaling:
     enabled: false
     minReplicaCount: 1
     maxReplicaCount: 10
-    pollingInterval: 15
+    pollingInterval: 30
     cooldownPeriod: 300
+    # Optional: HPA scaling behavior
+    # .stabilizationWindowSeconds prevents reacting to short CPU/metric spikes (e.g. during pod startup)
+    # by requiring the metric to stay above threshold for the full window before scaling up or down.
+    # advanced:
+    #   scaleUp:
+    #     stabilizationWindowSeconds: 180
+    #   scaleDown:
+    #     stabilizationWindowSeconds: 300
     # List of triggers that determine scaling behavior
     # See KEDA scalers: https://keda.sh/docs/scalers/
     triggers: []

--- a/charts/faceapi/Chart.yaml
+++ b/charts/faceapi/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: faceapi
 home: https://faceapi.regulaforensics.com/
-version: 3.2.0
+version: 3.6.0
 appVersion: 8.2.694.1636-cpu
 description: Face Recognition Service. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/faceapi/README.md
+++ b/charts/faceapi/README.md
@@ -120,6 +120,28 @@ env:
         key: config-key
 ```
 
+## In-cluster TLS (trusted CA bundle)
+
+When connecting to backends (MongoDB, S3/object storage, OpenSearch) over TLS signed by an
+internal/private CA, the application must trust that CA. Rather than rebuilding the image, set
+`tls.trustedCABundle.configMapName` to a ConfigMap containing a PEM CA bundle (for example one
+produced by [cert-manager trust-manager](https://cert-manager.io/docs/trust/trust-manager/),
+combining your private CA with the public CAs). The chart then mounts the bundle at
+`tls.trustedCABundle.mountPath` (use this path for clients taking an explicit CA file, e.g.
+MongoDB `tlsCAFile`), overlays it onto the image's CA store file(s) in
+`tls.trustedCABundle.caStorePaths` (the Python `certifi` store by default) so clients that read a
+bundled store (boto3/S3, opensearch-py) trust it, and sets `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`,
+and `AWS_CA_BUNDLE` environment variables as an additional layer of coverage.
+
+```yaml
+tls:
+  trustedCABundle:
+    configMapName: my-ca-bundle   # ConfigMap with key `ca-bundle.pem`
+```
+
+Disabled by default (`configMapName: ""`); changes nothing in existing releases.
+`caStorePaths` defaults target this image's layout; update when the image changes Python version.
+
 ## Common parameters
 
 | Parameter                             | Description                                                                                   | Default                       |
@@ -151,6 +173,10 @@ env:
 | `env`                                 | Additional environment variables (supports value, secretKeyRef, configMapKeyRef)              | `[]`                          |
 | `extraVolumes`                        | Additional Face-API volumes                                                                   | `[]`                          |
 | `extraVolumeMounts`                   | Additional Face-API volume mounts                                                             | `[]`                          |
+| `tls.trustedCABundle.configMapName`   | Name of a ConfigMap holding a CA bundle to trust for in-cluster TLS (e.g. from cert-manager trust-manager). Empty disables the feature | `""`        |
+| `tls.trustedCABundle.key`             | Key in the ConfigMap that holds the PEM CA bundle                                             | `ca-bundle.pem`               |
+| `tls.trustedCABundle.mountPath`       | Directory the bundle is mounted at (use for e.g. MongoDB `tlsCAFile`)                         | `/etc/regula/tls`             |
+| `tls.trustedCABundle.caStorePaths`    | CA-store file(s) overlaid with the bundle (image-version-dependent; update on Python upgrade)  | `[certifi cacert.pem]`        |
 | `service.type`                        | Kubernetes service type                                                                       | `ClusterIP`                   |
 | `service.port`                        | Kubernetes port where service is exposed                                                      | `80`                          |
 | `service.annotations`                 | Service annotations (can be templated)                                                        | `{}`                          |
@@ -185,6 +211,13 @@ env:
 | `startupProbe.enabled`                | Enable startupProbe                                                                           | `true`                        |
 | `autoscaling.enabled`                 | Enable autoscaling                                                                            | `false`                       |
 | `autoscaling.keda.enabled`            | Enable KEDA autoscaling                                                                       | `false`                       |
+| `autoscaling.keda.minReplicaCount`    | KEDA minimum replica count                                                                    | `1`                           |
+| `autoscaling.keda.maxReplicaCount`    | KEDA maximum replica count                                                                    | `10`                          |
+| `autoscaling.keda.pollingInterval`    | How frequently (seconds) KEDA polls the triggers                                              | `30`                          |
+| `autoscaling.keda.cooldownPeriod`     | Seconds to wait before scaling in after load drops                                            | `300`                         |
+| `autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling up                    | `180`                         |
+| `autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling down                | `300`                         |
+| `autoscaling.keda.triggers`           | List of KEDA scaler triggers                                                                  | `[]`                          |
 | `networkPolicy.enabled`               | Enable NetworkPolicy                                                                          | `false`                       |
 | `networkPolicy.annotations`           | NetworkPolicy annotations                                                                     | `{}`                          |
 | `networkPolicy.ingress`               | Set NetworkPolicy Ingress rules                                                               | `{}`                          |

--- a/charts/faceapi/templates/_helpers.tpl
+++ b/charts/faceapi/templates/_helpers.tpl
@@ -160,3 +160,42 @@ app.kubernetes.io/component: db-migration
 {{ .Release.Name }}-search-persons
 {{- end -}}
 {{- end -}}
+
+{{/*
+Optional trusted-CA bundle volume (enabled via tls.trustedCABundle.configMapName).
+*/}}
+{{- define "faceapi.caBundle.volumes" -}}
+- name: regula-ca-bundle
+  configMap:
+    name: {{ .Values.tls.trustedCABundle.configMapName }}
+{{- end -}}
+
+{{/*
+Trusted-CA bundle mount: the bundle is mounted as a directory so clients that take an explicit
+CA file path (e.g. MongoDB tlsCAFile) can reference it directly, plus per-CA-store file overlays
+so clients that read a bundled CA store (certifi, botocore) trust it.
+*/}}
+{{- define "faceapi.caBundle.volumeMounts" -}}
+- name: regula-ca-bundle
+  mountPath: {{ .Values.tls.trustedCABundle.mountPath }}
+  readOnly: true
+{{- range .Values.tls.trustedCABundle.caStorePaths }}
+- name: regula-ca-bundle
+  mountPath: {{ . }}
+  subPath: {{ $.Values.tls.trustedCABundle.key }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{/*
+TLS CA bundle environment variables. Sets SSL_CERT_FILE, REQUESTS_CA_BUNDLE, and AWS_CA_BUNDLE
+so all Python TLS clients trust the mounted bundle regardless of Python/package version.
+*/}}
+{{- define "faceapi.caBundle.env" -}}
+- name: SSL_CERT_FILE
+  value: {{ printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key }}
+- name: REQUESTS_CA_BUNDLE
+  value: {{ printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key }}
+- name: AWS_CA_BUNDLE
+  value: {{ printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key }}
+{{- end -}}

--- a/charts/faceapi/templates/db-migration-job.yaml
+++ b/charts/faceapi/templates/db-migration-job.yaml
@@ -68,6 +68,9 @@ spec:
                   name: {{ template "faceapi.db.credentials.secret" . }}
                   key: SQL_CONNECTION_STRING
             {{- end }}
+            {{- if .Values.tls.trustedCABundle.configMapName }}
+            {{- include "faceapi.caBundle.env" . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: faceapi-config
               mountPath: /app/config.yaml
@@ -76,11 +79,17 @@ spec:
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
+          {{- if .Values.tls.trustedCABundle.configMapName }}
+          {{- include "faceapi.caBundle.volumeMounts" . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: faceapi-config
           configMap:
             name: {{ include "faceapi.config.name" . }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tls.trustedCABundle.configMapName }}
+      {{- include "faceapi.caBundle.volumes" . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/faceapi/templates/deployment.yaml
+++ b/charts/faceapi/templates/deployment.yaml
@@ -130,6 +130,9 @@ spec:
                   name: {{ template "faceapi.db.credentials.secret" . }}
                   key: SQL_CONNECTION_STRING
             {{- end }}
+            {{- if .Values.tls.trustedCABundle.configMapName }}
+            {{- include "faceapi.caBundle.env" . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: faceapi-config
               mountPath: /app/config.yaml
@@ -167,6 +170,9 @@ spec:
 {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}
+{{- if .Values.tls.trustedCABundle.configMapName }}
+{{ include "faceapi.caBundle.volumeMounts" . | indent 12 }}
+{{- end }}
       volumes:
         - name: faceapi-config
           configMap:
@@ -203,4 +209,7 @@ spec:
         {{- end }}
 {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- if .Values.tls.trustedCABundle.configMapName }}
+{{ include "faceapi.caBundle.volumes" . | indent 8 }}
 {{- end }}

--- a/charts/faceapi/templates/keda-hpa.yaml
+++ b/charts/faceapi/templates/keda-hpa.yaml
@@ -13,6 +13,19 @@ spec:
   maxReplicaCount: {{ .Values.autoscaling.keda.maxReplicaCount | default 10 }}
   pollingInterval: {{ .Values.autoscaling.keda.pollingInterval | default 30 }} 
   cooldownPeriod: {{ .Values.autoscaling.keda.cooldownPeriod | default 300 }}
+  {{- if .Values.autoscaling.keda.advanced }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        {{- if .Values.autoscaling.keda.advanced.scaleUp }}
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds | default 180 }}
+        {{- end }}
+        {{- if .Values.autoscaling.keda.advanced.scaleDown }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds | default 300 }}
+        {{- end }}
+  {{- end }}
   triggers:
 {{- range .Values.autoscaling.keda.triggers }}
   - type: {{ .type }}

--- a/charts/faceapi/values.yaml
+++ b/charts/faceapi/values.yaml
@@ -421,6 +421,23 @@ env: []
 extraVolumes: []
 extraVolumeMounts: []
 
+# Optional: trust an internal/private CA for in-cluster TLS (e.g. to MongoDB, S3/MinIO,
+# OpenSearch) without rebuilding the image. Point `configMapName` at a ConfigMap (e.g. produced
+# by cert-manager trust-manager) holding a CA bundle under `key`. When set, the chart mounts the
+# bundle at `mountPath`, overlays it onto the image's CA store(s) listed in `caStorePaths`, and
+# sets SSL_CERT_FILE / REQUESTS_CA_BUNDLE / AWS_CA_BUNDLE env vars so all Python TLS clients
+# trust certificates signed by that CA. Disabled by default.
+tls:
+  trustedCABundle:
+    configMapName: ""
+    key: ca-bundle.pem
+    # Directory the bundle is mounted at (use this path for e.g. MongoDB tlsCAFile).
+    mountPath: /etc/regula/tls
+    # CA-store files to overlay with the bundle. Defaults target this image's layout;
+    # update when the image changes Python version.
+    caStorePaths:
+      - /app/.venv/lib/python3.11/site-packages/certifi/cacert.pem
+
 service:
   type: ClusterIP
   port: 80
@@ -616,8 +633,16 @@ autoscaling:
     enabled: false
     minReplicaCount: 1
     maxReplicaCount: 10
-    pollingInterval: 15
+    pollingInterval: 30
     cooldownPeriod: 300
+    # Optional: HPA scaling behavior
+    # .stabilizationWindowSeconds prevents reacting to short CPU/metric spikes (e.g. during pod startup)
+    # by requiring the metric to stay above threshold for the full window before scaling up or down.
+    # advanced:
+    #   scaleUp:
+    #     stabilizationWindowSeconds: 180
+    #   scaleDown:
+    #     stabilizationWindowSeconds: 300
     # List of triggers that determine scaling behavior
     # See KEDA scalers: https://keda.sh/docs/scalers/
     triggers: []

--- a/charts/idv/Chart.yaml
+++ b/charts/idv/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: idv
 home: https://idv.regula.app/
-version: 1.11.2
+version: 1.12.0
 appVersion: 3.7.1
 description: IDV Platform. On-premise and cloud integration
 icon: https://secure.gravatar.com/avatar/71a5efd69d82e444129ad18f51224bbb.jpg

--- a/charts/idv/README.md
+++ b/charts/idv/README.md
@@ -187,6 +187,12 @@ helm upgrade my-release regulaforensics/idv
 | `podAnnotations`                                          | Pod annotations                                   | `{}`                              |
 | `podSecurityContext`                                      | Pod security context                              | `{}`                              |
 | `securityContext`                                         | Container security context                        | `{}`                              |
+| `extraVolumes`                                            | Additional volumes added to all IDV deployments   | `[]`                              |
+| `extraVolumeMounts`                                       | Additional volume mounts added to all IDV deployments | `[]`                          |
+| `tls.trustedCABundle.configMapName`                       | ConfigMap holding a CA bundle to trust for in-cluster TLS (e.g. from cert-manager trust-manager). Empty disables the feature | `""` |
+| `tls.trustedCABundle.key`                                 | Key in the ConfigMap that holds the PEM CA bundle | `ca-bundle.pem`                   |
+| `tls.trustedCABundle.mountPath`                           | Directory the bundle is mounted at (use for e.g. MongoDB `tlsCAFile`) | `/etc/regula/tls`             |
+| `tls.trustedCABundle.caStorePaths`                        | CA-store file(s) overlaid with the bundle (image-version-dependent; update on Python upgrade) | `[botocore, certifi, system]` |
 | `versionSha`                                              | Version SHA tag                                   | `latest`                          |
 | `image.repository`                                        | Image repository                                  | `regulaforensics/idv-coordinator` |
 | `image.pullPolicy`                                        | Image pull policy                                 | `Always`                          |
@@ -215,6 +221,8 @@ helm upgrade my-release regulaforensics/idv
 | `api.autoscaling.keda.maxReplicaCount`                    | KEDA maximum replica count for API                | `100`                             |
 | `api.autoscaling.keda.cooldownPeriod`                     | KEDA cooldown period (seconds) for API            | `300`                             |
 | `api.autoscaling.keda.pollingInterval`                    | KEDA polling interval (seconds) for API           | `30`                              |
+| `api.autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling up | `180`                    |
+| `api.autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling down | `300`                |
 | `api.autoscaling.keda.triggers`                           | KEDA triggers for API                             | `[]`                              |
 | `api.autoscaling.keda.TriggerAuthentication`              | KEDA TriggerAuthentication for API                | `null`                            |
 | `api.autoscaling.keda.fallback`                           | KEDA fallback config when metrics unavailable     | `null`                            |
@@ -257,6 +265,8 @@ helm upgrade my-release regulaforensics/idv
 | `workflow.autoscaling.keda.maxReplicaCount`               | KEDA maximum replica count for Workflow           | `100`                             |
 | `workflow.autoscaling.keda.cooldownPeriod`                | KEDA cooldown period (seconds) for Workflow       | `300`                             |
 | `workflow.autoscaling.keda.pollingInterval`               | KEDA polling interval (seconds) for Workflow      | `30`                              |
+| `workflow.autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling up | `180`               |
+| `workflow.autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds` | Seconds the HPA observes metric before scaling down | `300`           |
 | `workflow.autoscaling.keda.triggers`                      | KEDA triggers for Workflow                        | `[]`                              |
 | `workflow.autoscaling.keda.TriggerAuthentication`         | KEDA TriggerAuthentication for Workflow           | `null`                            |
 | `workflow.autoscaling.keda.fallback`                      | KEDA fallback config when metrics unavailable     | `null`                            |
@@ -494,6 +504,33 @@ helm upgrade my-release regulaforensics/idv
 > [!NOTE]
 > The subcharts are used for the demonstration and Dev/Test purposes.
 > We strongly recommend to deploying separate installations of required resources in Production.
+
+## In-cluster TLS (trusted CA bundle)
+
+When IDV connects to its backends (MongoDB, S3/object storage, OpenSearch, RabbitMQ) over TLS
+signed by an internal/private CA, IDV must trust that CA. Rather than rebuilding the image, set
+`tls.trustedCABundle.configMapName` to a ConfigMap containing a PEM CA bundle (for example one
+produced by [cert-manager trust-manager](https://cert-manager.io/docs/trust/trust-manager/),
+combining your private CA with the public CAs). For **all five** IDV deployments the chart then:
+
+- mounts the bundle as a directory at `tls.trustedCABundle.mountPath` (use this path for clients
+  that take an explicit CA file, e.g. a MongoDB URL `…&tls=true&tlsCAFile=/etc/regula/tls/ca-bundle.pem`);
+- overlays the bundle onto the image's CA store file(s) in `tls.trustedCABundle.caStorePaths`
+  (by default the `botocore`, `certifi` and system stores — covering boto3/S3, opensearch-py and
+  py-amqp/pymongo respectively); and
+- sets `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, and `AWS_CA_BUNDLE` environment variables as an
+  additional layer of coverage.
+
+```yaml
+tls:
+  trustedCABundle:
+    configMapName: my-ca-bundle   # ConfigMap with key `ca-bundle.pem`
+```
+
+The feature is disabled by default (`configMapName: ""`) and changes nothing in existing releases.
+`caStorePaths` defaults target the idv-coordinator image; update when the image changes Python
+version. For in-cluster TLS to RabbitMQ, set the broker URL scheme to `amqps://`; for OpenSearch
+set `config.faceSearch.database.opensearch.verifyCerts: true` (and the same for `textSearch`).
 
 ## Subchart parameters
 

--- a/charts/idv/templates/_helpers.tpl
+++ b/charts/idv/templates/_helpers.tpl
@@ -204,3 +204,60 @@ initContainers:
     securityContext: {{- toYaml .Values.securityContext | nindent 6 }}
 {{- end }}
 {{- end }}
+
+{{/*
+TLS trusted CA bundle: file path of the mounted bundle.
+*/}}
+{{- define "idv.tls.bundleFile" -}}
+{{- printf "%s/%s" .Values.tls.trustedCABundle.mountPath .Values.tls.trustedCABundle.key -}}
+{{- end -}}
+
+{{/*
+Extra pod volumes: optional trusted-CA bundle ConfigMap + user-provided extraVolumes.
+Backward compatible: renders nothing unless tls.trustedCABundle.configMapName or extraVolumes is set.
+*/}}
+{{- define "idv.extraVolumes" -}}
+{{- if .Values.tls.trustedCABundle.configMapName }}
+- name: regula-ca-bundle
+  configMap:
+    name: {{ .Values.tls.trustedCABundle.configMapName }}
+{{- end }}
+{{- with .Values.extraVolumes }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Extra container volumeMounts: CA bundle as a directory (for clients that take an explicit CA
+path, e.g. MongoDB tlsCAFile) plus per-CA-store file overlays (for clients that read a bundled
+CA store such as certifi/botocore or the system trust store), then user extraVolumeMounts.
+*/}}
+{{- define "idv.extraVolumeMounts" -}}
+{{- if .Values.tls.trustedCABundle.configMapName }}
+- name: regula-ca-bundle
+  mountPath: {{ .Values.tls.trustedCABundle.mountPath }}
+  readOnly: true
+{{- range .Values.tls.trustedCABundle.caStorePaths }}
+- name: regula-ca-bundle
+  mountPath: {{ . }}
+  subPath: {{ $.Values.tls.trustedCABundle.key }}
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Full container env: when a trusted-CA bundle is configured, prepend the standard CA-bundle
+environment variables (honored by clients that read them), then the user-provided env.
+*/}}
+{{- define "idv.fullEnv" -}}
+{{- $env := .Values.env | default (list) -}}
+{{- if .Values.tls.trustedCABundle.configMapName -}}
+{{- $f := include "idv.tls.bundleFile" . -}}
+{{- $env = concat (list (dict "name" "SSL_CERT_FILE" "value" $f) (dict "name" "REQUESTS_CA_BUNDLE" "value" $f) (dict "name" "AWS_CA_BUNDLE" "value" $f)) $env -}}
+{{- end -}}
+{{- toYaml $env -}}
+{{- end -}}

--- a/charts/idv/templates/deployment-api.yaml
+++ b/charts/idv/templates/deployment-api.yaml
@@ -55,6 +55,9 @@ spec:
         secret:
           secretName: {{ template "idv.gcs.credentials.secret" . }}
       {{- end }}
+      {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumes }}
+      {{- include "idv.extraVolumes" . | nindent 6 }}
+      {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.api.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.api.terminationGracePeriodSeconds }}
@@ -120,6 +123,13 @@ spec:
           subPath: gcs_key.json
           readOnly: true
         {{- end }}
+        {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumeMounts }}
+        {{- include "idv.extraVolumeMounts" . | nindent 8 }}
+        {{- end }}
         command: ["idv"]
         args: ["webserver", "start"]
+        {{- if .Values.tls.trustedCABundle.configMapName }}
+        env: {{- tpl (include "idv.fullEnv" .) $ | nindent 10 }}
+        {{- else }}
         env: {{- tpl (toYaml .Values.env) . | nindent 10 }}
+        {{- end }}

--- a/charts/idv/templates/deployment-audit.yaml
+++ b/charts/idv/templates/deployment-audit.yaml
@@ -53,6 +53,9 @@ spec:
         secret:
           secretName: {{ template "idv.gcs.credentials.secret" . }}
       {{- end }}
+      {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumes }}
+      {{- include "idv.extraVolumes" . | nindent 6 }}
+      {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "idv.minioInitContainer" . | nindent 6 }}
       containers:
@@ -77,6 +80,13 @@ spec:
           subPath: gcs_key.json
           readOnly: true
         {{- end }}
+        {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumeMounts }}
+        {{- include "idv.extraVolumeMounts" . | nindent 8 }}
+        {{- end }}
         command: ["idv"]
         args: ["audit", "start"]
+        {{- if .Values.tls.trustedCABundle.configMapName }}
+        env: {{- tpl (include "idv.fullEnv" .) $ | nindent 10 }}
+        {{- else }}
         env: {{- tpl (toYaml .Values.env) . | nindent 10 }}
+        {{- end }}

--- a/charts/idv/templates/deployment-indexer.yaml
+++ b/charts/idv/templates/deployment-indexer.yaml
@@ -54,6 +54,9 @@ spec:
         secret:
           secretName: {{ template "idv.gcs.credentials.secret" . }}
       {{- end }}
+      {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumes }}
+      {{- include "idv.extraVolumes" . | nindent 6 }}
+      {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "idv.minioInitContainer" . | nindent 6 }}
       containers:
@@ -78,7 +81,14 @@ spec:
           subPath: gcs_key.json
           readOnly: true
         {{- end }}
+        {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumeMounts }}
+        {{- include "idv.extraVolumeMounts" . | nindent 8 }}
+        {{- end }}
         command: ["idv"]
         args: ["indexer", "start"]
+        {{- if .Values.tls.trustedCABundle.configMapName }}
+        env: {{- tpl (include "idv.fullEnv" .) $ | nindent 10 }}
+        {{- else }}
         env: {{- tpl (toYaml .Values.env) . | nindent 10 }}
+        {{- end }}
 {{- end }}

--- a/charts/idv/templates/deployment-scheduler.yaml
+++ b/charts/idv/templates/deployment-scheduler.yaml
@@ -53,6 +53,9 @@ spec:
         secret:
           secretName: {{ template "idv.gcs.credentials.secret" . }}
       {{- end }}
+      {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumes }}
+      {{- include "idv.extraVolumes" . | nindent 6 }}
+      {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "idv.minioInitContainer" . | nindent 6 }}
       containers:
@@ -77,7 +80,14 @@ spec:
           subPath: gcs_key.json
           readOnly: true
         {{- end }}
+        {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumeMounts }}
+        {{- include "idv.extraVolumeMounts" . | nindent 8 }}
+        {{- end }}
         command: ["idv"]
         args: ["scheduler", "start"]
+        {{- if .Values.tls.trustedCABundle.configMapName }}
+        env: {{- tpl (include "idv.fullEnv" .) $ | nindent 10 }}
+        {{- else }}
         env: {{- tpl (toYaml .Values.env) . | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: 30

--- a/charts/idv/templates/deployment-workflow.yaml
+++ b/charts/idv/templates/deployment-workflow.yaml
@@ -55,6 +55,9 @@ spec:
         secret:
           secretName: {{ template "idv.gcs.credentials.secret" . }}
       {{- end }}
+      {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumes }}
+      {{- include "idv.extraVolumes" . | nindent 6 }}
+      {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- include "idv.minioInitContainer" . | nindent 6 }}
       containers:
@@ -79,7 +82,14 @@ spec:
           subPath: gcs_key.json
           readOnly: true
         {{- end }}
+        {{- if or .Values.tls.trustedCABundle.configMapName .Values.extraVolumeMounts }}
+        {{- include "idv.extraVolumeMounts" . | nindent 8 }}
+        {{- end }}
         command: ["idv"]
         args: ["workflow", "start"]
+        {{- if .Values.tls.trustedCABundle.configMapName }}
+        env: {{- tpl (include "idv.fullEnv" .) $ | nindent 10 }}
+        {{- else }}
         env: {{- tpl (toYaml .Values.env) . | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: 30

--- a/charts/idv/templates/scaledobject-api.yaml
+++ b/charts/idv/templates/scaledobject-api.yaml
@@ -17,6 +17,19 @@ spec:
     failureThreshold: {{ .Values.api.autoscaling.keda.fallback.failureThreshold | default 3 }}
     replicas: {{ .Values.api.autoscaling.keda.fallback.replicas | default 1 }}
   {{- end }}
+  {{- if .Values.api.autoscaling.keda.advanced }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        {{- if .Values.api.autoscaling.keda.advanced.scaleUp }}
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.api.autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds | default 180 }}
+        {{- end }}
+        {{- if .Values.api.autoscaling.keda.advanced.scaleDown }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.api.autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds | default 300 }}
+        {{- end }}
+  {{- end }}
   triggers:
   {{- range .Values.api.autoscaling.keda.triggers }}
   - type: {{ .type }}

--- a/charts/idv/templates/scaledobject-workflow.yaml
+++ b/charts/idv/templates/scaledobject-workflow.yaml
@@ -17,6 +17,19 @@ spec:
     failureThreshold: {{ .Values.workflow.autoscaling.keda.fallback.failureThreshold | default 3 }}
     replicas: {{ .Values.workflow.autoscaling.keda.fallback.replicas | default 1 }}
   {{- end }}
+  {{- if .Values.workflow.autoscaling.keda.advanced }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        {{- if .Values.workflow.autoscaling.keda.advanced.scaleUp }}
+        scaleUp:
+          stabilizationWindowSeconds: {{ .Values.workflow.autoscaling.keda.advanced.scaleUp.stabilizationWindowSeconds | default 180 }}
+        {{- end }}
+        {{- if .Values.workflow.autoscaling.keda.advanced.scaleDown }}
+        scaleDown:
+          stabilizationWindowSeconds: {{ .Values.workflow.autoscaling.keda.advanced.scaleDown.stabilizationWindowSeconds | default 300 }}
+        {{- end }}
+  {{- end }}
   triggers:
   {{- range .Values.workflow.autoscaling.keda.triggers }}
   - type: {{ .type }}

--- a/charts/idv/values.yaml
+++ b/charts/idv/values.yaml
@@ -8,6 +8,30 @@ podAnnotations: {}
 podSecurityContext: {}
 securityContext: {}
 
+# Extra volumes and volumeMounts added to every IDV deployment (api, workflow, scheduler,
+# audit, indexer). Empty by default (no change to existing deployments).
+extraVolumes: []
+extraVolumeMounts: []
+
+# Optional: trust an internal/private CA for in-cluster TLS to backends without rebuilding the
+# image. Point `configMapName` at a ConfigMap (e.g. produced by cert-manager trust-manager)
+# holding a CA bundle under `key`. When set, the chart mounts the bundle at `mountPath`,
+# overlays it onto the image's CA store(s) listed in `caStorePaths`, and sets SSL_CERT_FILE /
+# REQUESTS_CA_BUNDLE / AWS_CA_BUNDLE env vars so all Python TLS clients trust certificates
+# signed by that CA. Disabled by default.
+tls:
+  trustedCABundle:
+    configMapName: ""
+    key: ca-bundle.pem
+    # Directory the bundle is mounted at (use this path for e.g. MongoDB tlsCAFile).
+    mountPath: /etc/regula/tls
+    # CA-store files to overlay with the bundle. Defaults target the idv-coordinator image;
+    # update when the image changes Python version.
+    caStorePaths:
+      - /app/.venv/lib/python3.11/site-packages/botocore/cacert.pem
+      - /app/.venv/lib/python3.11/site-packages/certifi/cacert.pem
+      - /etc/pki/tls/cert.pem
+
 versionSha: latest
 
 image:
@@ -58,7 +82,7 @@ api:
       enabled: false
       # KEDA-specific replica count settings (override autoscaling.minReplicas/maxReplicas)
       # minReplicaCount: 1
-      # maxReplicaCount: 10
+      # maxReplicaCount: 100
       # cooldownPeriod: 300
       # pollingInterval: 30
       triggers: []
@@ -70,6 +94,14 @@ api:
       # fallback:
       #   failureThreshold: 3
       #   replicas: 1
+      # Optional: HPA scaling behavior
+      # .stabilizationWindowSeconds prevents reacting to short CPU/metric spikes (e.g. during pod startup)
+      # by requiring the metric to stay above threshold for the full window before scaling up or down.
+      # advanced:
+      #   scaleUp:
+      #     stabilizationWindowSeconds: 180
+      #   scaleDown:
+      #     stabilizationWindowSeconds: 300
 
   # API pod disruption budget
   podDisruptionBudget:
@@ -138,6 +170,14 @@ workflow:
       # fallback:
       #   failureThreshold: 3
       #   replicas: 1
+      # Optional: HPA scaling behavior
+      # .stabilizationWindowSeconds prevents reacting to short CPU/metric spikes (e.g. during pod startup)
+      # by requiring the metric to stay above threshold for the full window before scaling up or down.
+      # advanced:
+      #   scaleUp:
+      #     stabilizationWindowSeconds: 180
+      #   scaleDown:
+      #     stabilizationWindowSeconds: 300
 
   # Workflow pod disruption budget
   podDisruptionBudget:


### PR DESCRIPTION
## Bump chart versions and add TLS/KEDA enhancements

### Chart versions
- docreader: 2.11.0 → 2.12.0 (appVersion: 9.5.321120.2224)
- faceapi: 3.2.0 → 3.6.0 (chart version aligned with internal release track; no breaking changes from 3.2.0)
- idv: 1.11.2 → 1.12.0

### In-cluster TLS trusted CA bundle (`tls.trustedCABundle`)

Adds opt-in support for trusting an internal/private CA across all three charts. When `tls.trustedCABundle.configMapName` is set, the chart:

- Mounts the CA bundle as a directory at `mountPath` (for explicit path references like MongoDB `tlsCAFile`)
- Overlays the bundle onto each image's bundled CA stores via `caStorePaths` (certifi for docreader/faceapi; botocore + certifi + system store for idv)
- Injects `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `AWS_CA_BUNDLE` env vars as defense-in-depth

Applied to deployments and db-migration-jobs (docreader/faceapi), and all 5 IDV deployments (api, workflow, scheduler, audit, indexer).

Disabled by default (`configMapName: ""`). No change to existing deployments.

### IDV: `extraVolumes` / `extraVolumeMounts`

Adds support for user-provided volumes and volume mounts across all 5 IDV deployments.

### KEDA ScaledObject improvements

- Increased default `pollingInterval` from 15s to 30s (reduces metric query load)
- Added optional `advanced` scaling behavior with configurable `stabilizationWindowSeconds` for scaleUp/scaleDown (prevents reacting to short metric spikes during pod startup)
- Applies to docreader, faceapi, and idv (api + workflow ScaledObjects)
